### PR TITLE
Update Skills and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cyberpunk 2020 Character Sheet Generator
 
-This project is a small Python app to generate blank a Cyberpunk 2020 character sheet with a custom selection of skills.
+This project is a small app to generate blank a Cyberpunk 2020 character sheet with a custom selection of skills.
+Both a local (Python 3.6+) and website version are available.
 It was created to allow referees to give their players non-standard skill options tailored to a campaign or setting.
 
 # Installation
@@ -42,17 +43,6 @@ To launch the app from a terminal, navigate to the `Character-Sheet-Generator` d
 `python charactersheetgen`
 
 The interface itself is simple; select the skills you want to include, then click "Generate" and a File Explorer window will open with the created pdf.
-
-# Backlog
-
-Future features that I want to implement, in no particular order.
-
-- Save skill profiles
-- Add new skills through the GUI
-- Check for updates to `skills.csv` on GitHub
-- Add an option to not always overwrite the previous file
-- Test Linux compatibility (it should work)
-- Build as a standalone Windows application
 
 <p align="right">
   <img src="https://i0.wp.com/rtalsoriangames.com/wp-content/uploads/2019/06/justcyberpunklogo.png" width="15%"/>

--- a/cp2020/skills.csv
+++ b/cp2020/skills.csv
@@ -12,7 +12,6 @@ Con,SPECIAL ABILITIES,0,False,CP3271,False
 Counsel,SPECIAL ABILITIES,0,False,CP3371,False
 Credibility,SPECIAL ABILITIES,0,False,CP3002,True
 Family,SPECIAL ABILITIES,0,False,CP3002,True
-Family,SPECIAL ABILITIES,0,False,CP3211,False
 Gang Rank,SPECIAL ABILITIES,0,False,CP3271,False
 Interface,SPECIAL ABILITIES,0,False,CP3002,True
 Jury Rig,SPECIAL ABILITIES,0,False,CP3002,True
@@ -141,7 +140,6 @@ Martial Art,REF,3,True,CP3002,True
 Melee,REF,0,False,CP3002,True
 Motorcycle,REF,0,False,CP3002,True
 Operate Hvy.Machinery,REF,0,False,CP3002,True
-Pilot (Blimp),REF,0,False,Ilsk,False
 Pilot (Boat),REF,0,False,Hate&Glory,False
 Pilot (Deep Dive Suit),REF,0,False,CP3481,False
 Pilot (Dirigible),REF,0,False,CP3002,True
@@ -175,7 +173,9 @@ Basic Tech,TECH,0,False,CP3002,True
 BioTech,TECH,0,False,CP3901,False
 Butchery,TECH,0,False,Hate&Glory,False
 Braindance Editing,TECH,0,False,CP3271,False
+CAD/CAM,TECH,0,False,UC-Mars,False
 Calligraphy,TECH,0,False,CP3311,False
+Cooking,TECH,0,False,Hate&Glory,False
 Cryotank Operation,TECH,0,False,CP3002,True
 CyberTech,TECH,0,False,CP3002,True
 Cyberdeck Design,TECH,0,False,CP3002,True

--- a/cp2020/skills.csv
+++ b/cp2020/skills.csv
@@ -174,7 +174,7 @@ BioTech,TECH,0,False,CP3901,False
 Butchery,TECH,0,False,Hate&Glory,False
 Braindance Editing,TECH,0,False,CP3271,False
 CAD/CAM,TECH,0,False,UC-Mars,False
-Calligraphy,TECH,0,False,CP3311,False
+Calligraphy,TECH,1,True,CP3311,False
 Cooking,TECH,0,False,Hate&Glory,False
 Cryotank Operation,TECH,0,False,CP3002,True
 CyberTech,TECH,0,False,CP3002,True
@@ -182,9 +182,9 @@ Cyberdeck Design,TECH,0,False,CP3002,True
 Demolitions,TECH,0,False,CP3002,True
 Disguise,TECH,0,False,CP3002,True
 Drone Control,TECH,0,False,Livewire,False
+Electronics,TECH,0,False,CP3002,True
 Elect. Security,TECH,0,False,CP3002,True
 Elect. Warfare,TECH,0,False,CP3481,False
-Electronics,TECH,0,False,CP3002,True
 First Aid,TECH,0,False,CP3002,True
 Forgery,TECH,0,False,CP3002,True
 Gyro Tech,TECH,0,False,CP3002,True


### PR DESCRIPTION
Skill Updates
- Removed _Deep Space [CP3211]_ varient of Family, as it does not actually exist in the book
- Removed pilot (Blimp)
- Add CAD/CAM
- Added cooking
- Made calligraphy an entry skill, as there are varients in _Pacific Rim [CP3311]_

Readme Updates
- Updated description
- Removed backlog, will be migrated to GitHub Issues